### PR TITLE
Streamline recovered artifacts inventory

### DIFF
--- a/README-AUDIT.md
+++ b/README-AUDIT.md
@@ -1,0 +1,115 @@
+# Audit du dépôt (hors-ligne)
+
+**Framework détecté** : Vite (React?)
+
+## Dépendances (72)
+- @eslint/js ^9.32.0
+- @hookform/resolvers ^3.10.0
+- @radix-ui/react-accordion ^1.2.11
+- @radix-ui/react-alert-dialog ^1.1.14
+- @radix-ui/react-aspect-ratio ^1.1.7
+- @radix-ui/react-avatar ^1.1.10
+- @radix-ui/react-checkbox ^1.3.2
+- @radix-ui/react-collapsible ^1.1.11
+- @radix-ui/react-context-menu ^2.2.15
+- @radix-ui/react-dialog ^1.1.14
+- @radix-ui/react-dropdown-menu ^2.1.15
+- @radix-ui/react-hover-card ^1.1.14
+- @radix-ui/react-label ^2.1.7
+- @radix-ui/react-menubar ^1.1.15
+- @radix-ui/react-navigation-menu ^1.2.13
+- @radix-ui/react-popover ^1.1.14
+- @radix-ui/react-progress ^1.1.7
+- @radix-ui/react-radio-group ^1.3.7
+- @radix-ui/react-scroll-area ^1.2.9
+- @radix-ui/react-select ^2.2.5
+- @radix-ui/react-separator ^1.1.7
+- @radix-ui/react-slider ^1.3.5
+- @radix-ui/react-slot ^1.2.3
+- @radix-ui/react-switch ^1.2.5
+- @radix-ui/react-tabs ^1.1.12
+- @radix-ui/react-toast ^1.2.14
+- @radix-ui/react-toggle ^1.1.9
+- @radix-ui/react-toggle-group ^1.1.10
+- @radix-ui/react-tooltip ^1.2.7
+- @tailwindcss/typography ^0.5.16
+- @tanstack/react-query ^5.83.0
+- @testing-library/dom ^10.4.1
+- @testing-library/jest-dom ^6.8.0
+- @testing-library/react ^16.3.0
+- @types/node ^22.16.5
+- @types/react ^18.3.23
+- @types/react-dom ^18.3.7
+- @vitejs/plugin-react-swc ^3.11.0
+- autoprefixer ^10.4.21
+- class-variance-authority ^0.7.1
+- clsx ^2.1.1
+- cmdk ^1.1.1
+- date-fns ^3.6.0
+- embla-carousel-react ^8.6.0
+- eslint ^9.32.0
+- eslint-plugin-react-hooks ^5.2.0
+- eslint-plugin-react-refresh ^0.4.20
+- globals ^15.15.0
+- input-otp ^1.4.2
+- jsdom ^26.1.0
+- lovable-tagger ^1.1.9
+- lucide-react ^0.462.0
+- mapbox-gl ^3.14.0
+- next-themes ^0.3.0
+- postcss ^8.5.6
+- react ^18.3.1
+- react-day-picker ^8.10.1
+- react-dom ^18.3.1
+- react-hook-form ^7.61.1
+- react-resizable-panels ^2.1.9
+- react-router-dom ^6.30.1
+- recharts ^2.15.4
+- sonner ^1.7.4
+- tailwind-merge ^2.6.0
+- tailwindcss ^3.4.17
+- tailwindcss-animate ^1.0.7
+- typescript ^5.8.3
+- typescript-eslint ^8.38.0
+- vaul ^0.9.9
+- vite ^5.4.19
+- vitest ^3.2.4
+- zod ^3.25.76
+
+## Configs détectées
+- tailwind.config.ts
+- tsconfig.json
+
+## Routes/pages (App Router)
+_Aucune_
+
+## Routes/pages (pages/)
+_Aucune_
+
+## Médias les plus lourds (Top 50)
+- public/lovable-uploads/0b1d45f0-c3dd-413d-89aa-6d7a070b4f6d.png — 1.84 MB
+- public/lovable-uploads/ab7525ee-de5e-4ec5-bd8a-474c543dff10.png — 1.37 MB
+- public/placeholder.svg — 0.00 MB
+
+## Fichiers de contenu détectés (.md/.mdx/.json)
+- README-AUDIT.md
+- README.md
+- TASKS.md
+- components.json
+- package-lock.json
+- package.json
+- tsconfig.app.json
+- tsconfig.json
+- tsconfig.node.json
+
+## Quick wins
+1. Optimiser les images > 1 MB (WebP/AVIF, variants 800/1200/1600).
+2. Séparer le contenu en MDX (content/etapes) pour édition simple.
+3. Ajouter metas SEO + og:image par page.
+4. Activer lazy + dimensions fixes sur toutes les images.
+5. Sitemap.xml + robots.txt.
+6. Nettoyer dépendances orphelines.
+7. Activer une CI minimale build/lint/typecheck.
+8. Page /galerie avec Masonry + Lightbox.
+9. Recherche client (Fuse.js) sur titre/tags/texte.
+10. Carte itinéraire Leaflet/MapLibre synchronisée avec la timeline.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,14 @@
+# Issue #1 — Audit automatisé du dépôt (version hors-ligne)
+
+Objectif : produire README-AUDIT.md (stack, routes, deps, médias, quick wins) **sans** dépendre d’installations npm.
+
+## Étapes
+- [ ] Ajouter deux scripts Node **sans dépendances** :
+  - `scripts/audit-repo-node.mjs` (génère README-AUDIT.md)
+  - `scripts/recover-content-node.mjs` (sauvegarde contenus dans _recovered/)
+- [ ] Exécuter ces scripts avec `node` (pas de npm install).
+- [ ] Commiter README-AUDIT.md et le dossier _recovered/.
+
+## Commandes
+node scripts/audit-repo-node.mjs
+node scripts/recover-content-node.mjs

--- a/_recovered/RECOVERY.md
+++ b/_recovered/RECOVERY.md
@@ -1,0 +1,17 @@
+# Récupération (2025-09-21T11:37:55.238Z)
+
+## Fichiers de contenu détectés (9)
+- README-AUDIT.md — 0.00 MB
+- README.md — 0.00 MB
+- TASKS.md — 0.00 MB
+- components.json — 0.00 MB
+- package-lock.json — 0.30 MB
+- package.json — 0.00 MB
+- tsconfig.app.json — 0.00 MB
+- tsconfig.json — 0.00 MB
+- tsconfig.node.json — 0.00 MB
+
+## Médias ignorés (non copiés) (3)
+- public/lovable-uploads/0b1d45f0-c3dd-413d-89aa-6d7a070b4f6d.png
+- public/lovable-uploads/ab7525ee-de5e-4ec5-bd8a-474c543dff10.png
+- public/placeholder.svg

--- a/scripts/audit-repo-node.mjs
+++ b/scripts/audit-repo-node.mjs
@@ -1,0 +1,90 @@
+// Audit "hors-ligne" sans npm install ni accès réseau
+import fs from 'fs'
+import path from 'path'
+const cwd = process.cwd()
+
+function readJSON(p) { try { return JSON.parse(fs.readFileSync(p,'utf8')) } catch { return null } }
+function exists(p) { return fs.existsSync(p) }
+function listFiles(dir, exts=new Set(), max=10000) {
+  const out = []
+  function walk(d) {
+    let entries = []
+    try { entries = fs.readdirSync(d, { withFileTypes:true }) } catch { return }
+    for (const e of entries) {
+      const full = path.join(d, e.name)
+      if (e.isDirectory()) {
+        if (['.git','node_modules','_recovered','.next','dist','build','.vercel','.cache'].includes(e.name)) continue
+        walk(full)
+      } else {
+        if (exts.size === 0) out.push(full)
+        else {
+          const ext = path.extname(e.name).toLowerCase()
+          if (exts.has(ext)) out.push(full)
+        }
+        if (out.length >= max) return
+      }
+    }
+  }
+  walk(dir)
+  return out
+}
+
+// 1) package.json / deps
+const pkg = readJSON(path.join(cwd,'package.json')) || { scripts:{}, dependencies:{}, devDependencies:{} }
+const allDeps = Object.assign({}, pkg.dependencies||{}, pkg.devDependencies||{})
+const depNames = Object.keys(allDeps).sort()
+
+// 2) détecter framework
+let framework = 'Inconnu'
+if ('next' in allDeps) framework = 'Next.js'
+else if ('astro' in allDeps) framework = 'Astro'
+else if ('vite' in allDeps) framework = 'Vite (React?)'
+
+// 3) routes/pages courantes
+const routeExts = new Set(['.tsx','.jsx','.ts','.js','.mdx','.md'])
+const appPages = exists('app') ? listFiles('app', routeExts, 5000).filter(f => /[\\/]page\.(tsx|jsx|mdx|ts|js)$/.test(f)) : []
+const pagesDir = exists('pages') ? listFiles('pages', routeExts, 5000) : []
+
+// 4) médias lourds
+const mediaExts = new Set(['.jpg','.jpeg','.png','.webp','.avif','.gif','.svg'])
+const media = exists('public') ? listFiles('public', mediaExts, 20000) : []
+const mediaSizes = media.map(f => {
+  let s = 0; try { s = fs.statSync(f).size } catch {}
+  return { file:f, MB:(s/1e6) }
+}).sort((a,b)=>b.MB-a.MB).slice(0,50)
+
+// 5) fichiers “contenu” possibles
+const contentFiles = listFiles('.', new Set(['.md','.mdx','.json']), 20000)
+  .filter(f => !f.includes('node_modules') && !f.includes('/.git/') && !f.includes('/_recovered/'))
+
+// 6) configs présentes
+const configs = ['next.config.js','next.config.ts','tailwind.config.js','tailwind.config.ts','astro.config.mjs','.eslintrc.js','.eslintrc.cjs','tsconfig.json','.prettierrc','contentlayer.config.ts']
+  .filter(exists)
+
+// 7) quick wins
+const quickWins = [
+  'Optimiser les images > 1 MB (WebP/AVIF, variants 800/1200/1600).',
+  'Séparer le contenu en MDX (content/etapes) pour édition simple.',
+  'Ajouter metas SEO + og:image par page.',
+  'Activer lazy + dimensions fixes sur toutes les images.',
+  'Sitemap.xml + robots.txt.',
+  'Nettoyer dépendances orphelines.',
+  'Activer une CI minimale build/lint/typecheck.',
+  'Page /galerie avec Masonry + Lightbox.',
+  'Recherche client (Fuse.js) sur titre/tags/texte.',
+  'Carte itinéraire Leaflet/MapLibre synchronisée avec la timeline.'
+]
+
+// 8) sortie README-AUDIT.md
+const lines = []
+lines.push(`# Audit du dépôt (hors-ligne)`)
+lines.push(`\n**Framework détecté** : ${framework}\n`)
+lines.push(`## Dépendances (${depNames.length})\n${depNames.map(d=>`- ${d} ${allDeps[d]}`).join('\n') || '_Aucune_'}\n`)
+lines.push(`## Configs détectées\n${configs.map(c=>`- ${c}`).join('\n') || '_Aucune_'}\n`)
+lines.push(`## Routes/pages (App Router)\n${appPages.map(p=>`- ${p}`).join('\n') || '_Aucune_'}\n`)
+lines.push(`## Routes/pages (pages/)\n${pagesDir.map(p=>`- ${p}`).join('\n') || '_Aucune_'}\n`)
+lines.push(`## Médias les plus lourds (Top 50)\n${mediaSizes.map(m=>`- ${m.file} — ${m.MB.toFixed(2)} MB`).join('\n') || '_Aucun_'}\n`)
+lines.push(`## Fichiers de contenu détectés (.md/.mdx/.json)\n${contentFiles.slice(0,200).map(f=>`- ${f}`).join('\n') || '_Aucun_'}\n`)
+lines.push(`## Quick wins\n${quickWins.map((q,i)=>`${i+1}. ${q}`).join('\n')}\n`)
+fs.writeFileSync('README-AUDIT.md', lines.join('\n'), 'utf8')
+console.log('✅ README-AUDIT.md généré (mode hors-ligne)')

--- a/scripts/recover-content-node.mjs
+++ b/scripts/recover-content-node.mjs
@@ -1,0 +1,70 @@
+// Sauvetage "hors-ligne" : inventorie les contenus texte et médias sans copier les binaires
+import fs from 'fs'
+import path from 'path'
+
+const OUT_DIR = '_recovered'
+const OUT_FILE = path.join(OUT_DIR, 'RECOVERY.md')
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+function walk(dir, cb) {
+  let entries = []
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (['node_modules', '.git', '_recovered', '.next', 'dist', 'build', '.vercel', '.cache'].includes(entry.name)) continue
+      walk(full, cb)
+    } else {
+      cb(full)
+    }
+  }
+}
+
+const keptContent = []
+const skippedMedia = []
+
+walk('.', (file) => {
+  const ext = path.extname(file).toLowerCase()
+  const isContent = ['.md', '.mdx', '.json'].includes(ext)
+  const isMedia = file.startsWith('public/') && ['.jpg', '.jpeg', '.png', '.webp', '.avif', '.gif', '.svg'].includes(ext)
+  if (isContent) {
+    let size = 0
+    try {
+      size = fs.statSync(file).size
+    } catch {
+      size = 0
+    }
+    keptContent.push({ file, size })
+  } else if (isMedia) {
+    skippedMedia.push(file)
+  }
+})
+
+const now = new Date().toISOString()
+const lines = []
+lines.push(`# Récupération (${now})\n`)
+lines.push(`## Fichiers de contenu détectés (${keptContent.length})`)
+if (keptContent.length === 0) {
+  lines.push('_Aucun_\n')
+} else {
+  for (const item of keptContent) {
+    lines.push(`- ${item.file} — ${(item.size / 1e6).toFixed(2)} MB`)
+  }
+  lines.push('')
+}
+lines.push(`## Médias ignorés (non copiés) (${skippedMedia.length})`)
+if (skippedMedia.length === 0) {
+  lines.push('_Aucun_\n')
+} else {
+  for (const file of skippedMedia) {
+    lines.push(`- ${file}`)
+  }
+  lines.push('')
+}
+
+fs.writeFileSync(OUT_FILE, lines.join('\n'), 'utf8')
+console.log(`✅ Inventaire sauvegardé dans ${OUT_FILE}`)


### PR DESCRIPTION
## Summary
- drop the dated _recovered/2025-09-21 snapshot and keep only a lightweight inventory file
- update the recovery script to emit _recovered/RECOVERY.md without copying binary media assets
- regenerate README-AUDIT.md so the content inventory reflects the streamlined recovery output

## Testing
- node scripts/recover-content-node.mjs
- node scripts/audit-repo-node.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfdafde19c8322929f76e04194294f