### PR TITLE
feat: add content store and canonical tracking

### DIFF
--- a/src/__tests__/Map.integration.test.tsx
+++ b/src/__tests__/Map.integration.test.tsx
@@ -92,6 +92,7 @@ describe('Map Integration Tests', () => {
     mockUseJournalEntries.mockReturnValue({
       allEntries: mockEntries,
       customEntries: mockEntries,
+      isCustom: vi.fn().mockReturnValue(false),
       isLoading: false,
       error: null,
       addEntry: vi.fn(),

--- a/src/__tests__/Map.test.tsx
+++ b/src/__tests__/Map.test.tsx
@@ -95,17 +95,26 @@ describe('Map Component', () => {
     }
   ];
 
+  const createHookValue = (overrides: Partial<Record<string, any>> = {}) => ({
+    allEntries: mockJournalEntries,
+    customEntries: mockJournalEntries,
+    isCustom: vi.fn().mockReturnValue(false),
+    isLoading: false,
+    error: null,
+    addEntry: vi.fn(),
+    editEntry: vi.fn(),
+    getStats: vi.fn(),
+    reloadEntries: vi.fn(),
+    ...overrides,
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('SPÉCIFICATION: Interface initiale sans token', () => {
     it('devrait afficher le formulaire de configuration Mapbox quand aucun token n\'est fourni', () => {
-      mockUseJournalEntries.mockReturnValue({
-        allEntries: mockJournalEntries,
-        isLoading: false,
-        error: null
-      });
+      mockUseJournalEntries.mockReturnValue(createHookValue());
 
       render(<Map />);
 
@@ -116,11 +125,10 @@ describe('Map Component', () => {
     });
 
     it('devrait désactiver le bouton si aucune entrée de journal n\'existe', () => {
-      mockUseJournalEntries.mockReturnValue({
+      mockUseJournalEntries.mockReturnValue(createHookValue({
         allEntries: [],
-        isLoading: false,
-        error: null
-      });
+        customEntries: [],
+      }));
 
       render(<Map />);
 
@@ -132,11 +140,7 @@ describe('Map Component', () => {
 
   describe('SPÉCIFICATION: Géocodage automatique des entrées du journal', () => {
     it('devrait analyser automatiquement les lieux du journal quand un token valide est fourni', async () => {
-      mockUseJournalEntries.mockReturnValue({
-        allEntries: mockJournalEntries,
-        isLoading: false,
-        error: null
-      });
+      mockUseJournalEntries.mockReturnValue(createHookValue());
 
       mockGeocodeJournalEntries.mockResolvedValue(expectedGeocodeResults);
 
@@ -166,11 +170,7 @@ describe('Map Component', () => {
     });
 
     it('devrait afficher les lieux détectés dans le modal de validation', async () => {
-      mockUseJournalEntries.mockReturnValue({
-        allEntries: mockJournalEntries,
-        isLoading: false,
-        error: null
-      });
+      mockUseJournalEntries.mockReturnValue(createHookValue());
 
       mockGeocodeJournalEntries.mockResolvedValue(expectedGeocodeResults);
 
@@ -191,11 +191,7 @@ describe('Map Component', () => {
     });
 
     it('devrait gérer les erreurs de géocodage avec un message d\'erreur explicite', async () => {
-      mockUseJournalEntries.mockReturnValue({
-        allEntries: mockJournalEntries,
-        isLoading: false,
-        error: null
-      });
+      mockUseJournalEntries.mockReturnValue(createHookValue());
 
       const mockAlert = vi.spyOn(window, 'alert').mockImplementation(() => {});
       mockGeocodeJournalEntries.mockRejectedValue(new Error('Token invalide'));
@@ -216,11 +212,7 @@ describe('Map Component', () => {
     });
 
     it('devrait afficher un avertissement si aucun lieu n\'est géocodé avec succès', async () => {
-      mockUseJournalEntries.mockReturnValue({
-        allEntries: mockJournalEntries,
-        isLoading: false,
-        error: null
-      });
+      mockUseJournalEntries.mockReturnValue(createHookValue());
 
       const mockAlert = vi.spyOn(window, 'alert').mockImplementation(() => {});
       mockGeocodeJournalEntries.mockResolvedValue([]);

--- a/src/__tests__/useJournalEntries.test.ts
+++ b/src/__tests__/useJournalEntries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useJournalEntries } from '@/hooks/useJournalEntries';
 import * as journalStorageModule from '@/lib/journalStorage';
+import * as contentStoreModule from '@/lib/contentStore';
 
 // Mock du module journalStorage
 vi.mock('@/lib/journalStorage', () => ({
@@ -9,6 +10,11 @@ vi.mock('@/lib/journalStorage', () => ({
   addJournalEntry: vi.fn(),
   updateJournalEntry: vi.fn(),
   getJournalStats: vi.fn()
+}));
+
+vi.mock('@/lib/contentStore', () => ({
+  getJournalEntriesWithSource: vi.fn(),
+  isCustomJournalDay: vi.fn()
 }));
 
 describe('SPÉCIFICATION: Hook useJournalEntries', () => {
@@ -33,19 +39,28 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     }
   ];
 
+  const mockEntriesWithSource = mockEntries.map(entry => ({
+    ...entry,
+    source: 'custom' as const
+  }));
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(contentStoreModule.isCustomJournalDay).mockReturnValue(false);
   });
 
   describe('SPÉCIFICATION: Chargement initial des entrées', () => {
     it('devrait charger les entrées au montage du composant', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue(mockEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue(mockEntriesWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
       expect(mockLoadJournalEntries).toHaveBeenCalledOnce();
-      expect(result.current.allEntries).toEqual(mockEntries);
+      expect(mockGetJournalEntriesWithSource).toHaveBeenCalledWith(mockEntries);
+      expect(result.current.allEntries).toEqual(mockEntriesWithSource);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBeNull();
     });
@@ -71,6 +86,9 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       const unorderedEntries = [...mockEntries].reverse(); // Jour 2, puis jour 1
       mockLoadJournalEntries.mockReturnValue(unorderedEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      const unorderedWithSource = unorderedEntries.map(entry => ({ ...entry, source: 'custom' as const }));
+      mockGetJournalEntriesWithSource.mockReturnValue(unorderedWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
@@ -84,6 +102,8 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     it('devrait exposer allEntries avec les données de localisation nécessaires', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue(mockEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue(mockEntriesWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
@@ -104,6 +124,8 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     it('devrait retourner les bonnes données de test pour le géocodage', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue(mockEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue(mockEntriesWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
@@ -126,11 +148,37 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     it('devrait maintenir la compatibilité avec customEntries', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue(mockEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue(mockEntriesWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
       // Vérifier la rétrocompatibilité
       expect(result.current.customEntries).toEqual(result.current.allEntries);
+    });
+
+    it('devrait distinguer les entrées canons et custom', () => {
+      const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
+      const canonicalEntry = { ...mockEntries[0] };
+      const customEntry = { ...mockEntries[1] };
+      mockLoadJournalEntries.mockReturnValue([canonicalEntry, customEntry]);
+
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue([
+        { ...canonicalEntry, source: 'canonical' as const },
+        { ...customEntry, source: 'custom' as const }
+      ]);
+
+      const mockIsCustomJournalDay = vi.mocked(contentStoreModule.isCustomJournalDay);
+      mockIsCustomJournalDay.mockImplementation(day => day === customEntry.day);
+
+      const { result } = renderHook(() => useJournalEntries());
+
+      expect(result.current.allEntries[0].source).toBe('canonical');
+      expect(result.current.customEntries).toHaveLength(1);
+      expect(result.current.customEntries[0].day).toBe(customEntry.day);
+      expect(result.current.isCustom(customEntry.day)).toBe(true);
+      expect(result.current.isCustom(canonicalEntry.day)).toBe(false);
     });
   });
 
@@ -138,6 +186,8 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     it('devrait indiquer isLoading=true pendant le chargement initial', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue([]);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue([]);
 
       const { result } = renderHook(() => useJournalEntries());
 
@@ -148,11 +198,14 @@ describe('SPÉCIFICATION: Hook useJournalEntries', () => {
     it('devrait permettre le rechargement manuel des entrées', () => {
       const mockLoadJournalEntries = vi.mocked(journalStorageModule.loadJournalEntries);
       mockLoadJournalEntries.mockReturnValue(mockEntries);
+      const mockGetJournalEntriesWithSource = vi.mocked(contentStoreModule.getJournalEntriesWithSource);
+      mockGetJournalEntriesWithSource.mockReturnValue(mockEntriesWithSource);
 
       const { result } = renderHook(() => useJournalEntries());
 
       // Vider les entrées et recharger
       mockLoadJournalEntries.mockReturnValue([]);
+      mockGetJournalEntriesWithSource.mockReturnValue([]);
       result.current.reloadEntries();
 
       expect(mockLoadJournalEntries).toHaveBeenCalledTimes(2); // Initial + reload

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -1,0 +1,361 @@
+import type { JournalEntry } from '@/lib/journalStorage';
+
+export type ContentSource = 'canonical' | 'custom';
+
+export interface JournalContentEntry extends JournalEntry {
+  source: ContentSource;
+}
+
+export interface PlaceReference {
+  day: number;
+  name: string;
+  summary: string;
+  coordinates: [number, number];
+  source: ContentSource;
+}
+
+export interface FoodExperience {
+  name: string;
+  type: string;
+  description: string;
+  experience: string;
+  rating: number;
+  location: string;
+  price: string;
+  source: ContentSource;
+}
+
+export interface ReadingRecommendation {
+  title: string;
+  author: string;
+  type: string;
+  description: string;
+  why: string;
+  amazon: string;
+  rating: number;
+  source: ContentSource;
+}
+
+const JOURNAL_STORAGE_KEY = 'journalEntries';
+const VERSION_KEY = 'journalStorage_version';
+const SOURCE_STATE_KEY = 'contentStore_sources';
+const CURRENT_VERSION = '3.0';
+
+interface SourceState {
+  journal: Record<number, ContentSource>;
+  hasImported?: boolean;
+}
+
+const defaultSourceState: SourceState = {
+  journal: {},
+  hasImported: false,
+};
+
+const canonicalJournalEntries: JournalContentEntry[] = [
+  {
+    day: 1,
+    date: '15 janvier 2024',
+    title: 'Arrivée à Amman',
+    location: 'Amman, Jordanie',
+    story: [
+      "Après un vol nocturne bercé par la lumière des étoiles, je touche enfin le sol jordanien.",
+      "L'odeur de cardamome du café arabe embaume l'aérogare de Queen Alia tandis que je franchis les portes de l'immigration.",
+      "Un chauffeur souriant m'attend avec un panneau griffonné à la main : premier sourire, première conversation, première invitation à ralentir et à écouter.",
+    ].join('\n\n'),
+    mood: 'Excité',
+    photos: ['/lovable-uploads/ab7525ee-de5e-4ec5-bd8a-474c543dff10.png'],
+    link: 'https://maps.app.goo.gl/2CwZq8vSxcrb3MBv7',
+    source: 'canonical',
+  },
+  {
+    day: 2,
+    date: '16 janvier 2024',
+    title: 'Jerash et les collines du Nord',
+    location: 'Jerash, Ajloun, Amman',
+    story: [
+      "Au lever du soleil, la lumière découpe les colonnades de Jerash comme une scène de théâtre antique.",
+      "Les ruines racontent la grandeur de la Décapole pendant qu'à Ajloun, les pierres du château portent encore l'écho des croisades.",
+      "La journée s'achève à Amman autour d'un mansaf partagé avec la famille de mon hôte : un festin autant culturel que gastronomique.",
+    ].join('\n\n'),
+    mood: 'Émerveillé',
+    link: 'https://maps.app.goo.gl/g3PDc28B4wXCRB4x6',
+    source: 'canonical',
+  },
+];
+
+const canonicalPlaceReferences: PlaceReference[] = [
+  {
+    day: 1,
+    name: 'Amman',
+    summary: 'Capitale du royaume hachémite, point de départ et de retour du voyage.',
+    coordinates: [31.9539, 35.9106],
+    source: 'canonical',
+  },
+  {
+    day: 2,
+    name: 'Jerash',
+    summary: 'Cité gréco-romaine remarquablement conservée, joyau du nord jordanien.',
+    coordinates: [32.2811, 35.8998],
+    source: 'canonical',
+  },
+  {
+    day: 2,
+    name: 'Ajloun',
+    summary: 'Forteresse ayyoubide veillant sur les vallées verdoyantes et les oliveraies.',
+    coordinates: [32.3326, 35.7519],
+    source: 'canonical',
+  },
+];
+
+const canonicalFoodExperiences: FoodExperience[] = [
+  {
+    name: 'Mansaf',
+    type: 'Plat national',
+    description: "Le plat emblématique jordanien : agneau cuit dans une sauce au yaourt fermenté (jameed), servi sur un lit de riz et mangé traditionnellement avec les mains.",
+    experience: "Partagé lors d'un déjeuner familial à Amman. L'expérience était autant sociale que gustative - toute la famille mange dans le même plat, créant une intimité particulière.",
+    rating: 5,
+    location: 'Restaurant familial, Amman',
+    price: 'Modéré',
+    source: 'canonical',
+  },
+  {
+    name: 'Falafel et Houmous',
+    type: 'Street food',
+    description: "Boulettes de pois chiches frites servies avec houmous crémeux, tahini, et légumes frais dans du pain pita chaud.",
+    experience: "Découvert dans une petite échoppe près du théâtre romain. Le propriétaire m'a expliqué ses secrets : pois chiches trempés 24h et épices moulues chaque matin.",
+    rating: 4,
+    location: 'Downtown Amman',
+    price: 'Très abordable',
+    source: 'canonical',
+  },
+  {
+    name: 'Knafeh',
+    type: 'Dessert',
+    description: "Dessert traditionnel au fromage fondu recouvert de cheveux d'ange (kataifi) et arrosé de sirop parfumé à l'eau de rose.",
+    experience: "Une révélation ! La version de Nablus dégustée à Amman était parfaite : croquant du dessus, fondant à l'intérieur. Un équilibre sucré-salé surprenant.",
+    rating: 5,
+    location: 'Pâtisserie Al-Aker, Amman',
+    price: 'Abordable',
+    source: 'canonical',
+  },
+  {
+    name: 'Thé à la menthe et café arabe',
+    type: 'Boissons',
+    description: "Thé noir parfumé à la menthe fraîche et café arabe (qahwa) parfumé à la cardamome, servis dans de petits verres.",
+    experience: "Rituel quotidien dans chaque lieu visité. Le thé accompagne chaque conversation, chaque pause. Le café arabe, plus corsé, ponctue les moments importants.",
+    rating: 4,
+    location: 'Partout',
+    price: 'Très abordable',
+    source: 'canonical',
+  },
+];
+
+const canonicalReadingRecommendations: ReadingRecommendation[] = [
+  {
+    title: "Lawrence d'Arabie",
+    author: 'T.E. Lawrence',
+    type: 'Autobiographie',
+    description: "Le récit captivant de l'officier britannique qui a vécu la révolte arabe de 1916-1918. Une plongée dans l'histoire du Moyen-Orient moderne.",
+    why: "Indispensable pour comprendre l'histoire moderne de la région et l'émergence de la Jordanie moderne sous l'émir Abdullah.",
+    amazon: 'https://amazon.fr/...',
+    rating: 5,
+    source: 'canonical',
+  },
+  {
+    title: 'Pétra : Merveille du monde',
+    author: 'Jane Taylor',
+    type: 'Guide culturel',
+    description: "Guide complet sur l'histoire, l'archéologie et l'art nabatéen de Pétra. Avec de magnifiques photographies et plans détaillés.",
+    why: "Le guide de référence pour comprendre l'ingéniosité nabatéenne et l'importance historique du site.",
+    amazon: 'https://amazon.fr/...',
+    rating: 4,
+    source: 'canonical',
+  },
+  {
+    title: 'Les Bédouins de Jordanie',
+    author: 'Shelagh Weir',
+    type: 'Anthropologie',
+    description: "Étude approfondie de la culture bédouine traditionnelle, ses traditions, son artisanat et son mode de vie.",
+    why: "Pour découvrir l'âme nomade de la Jordanie et comprendre l'hospitalité légendaire de ses habitants.",
+    amazon: 'https://amazon.fr/...',
+    rating: 4,
+    source: 'canonical',
+  },
+  {
+    title: 'Cuisine du Moyen-Orient',
+    author: 'Claudia Roden',
+    type: 'Gastronomie',
+    description: "Bible de la cuisine moyen-orientale avec des recettes authentiques jordaniennes, palestiniennes et syriennes.",
+    why: "Pour reproduire chez soi les saveurs découvertes et prolonger le voyage culinaire.",
+    amazon: 'https://amazon.fr/...',
+    rating: 5,
+    source: 'canonical',
+  },
+  {
+    title: 'Jordan: A Timeless Land',
+    author: 'Mohamed El-Khoury',
+    type: 'Beau livre',
+    description: "Superbe livre photographique qui capture la beauté des paysages jordaniens, de Pétra au Wadi Rum.",
+    why: "Pour revivre visuellement la magie des paysages jordaniens et partager la beauté du pays.",
+    amazon: 'https://amazon.fr/...',
+    rating: 4,
+    source: 'canonical',
+  },
+  {
+    title: 'Le Royaume hachémite de Jordanie',
+    author: 'Philippe Droz-Vincent',
+    type: 'Géopolitique',
+    description: 'Analyse politique et sociale de la Jordanie contemporaine, son rôle régional et ses défis.',
+    why: 'Pour comprendre les enjeux actuels du royaume et son importance stratégique au Moyen-Orient.',
+    amazon: 'https://amazon.fr/...',
+    rating: 4,
+    source: 'canonical',
+  },
+];
+
+const stripSource = (entry: JournalContentEntry): JournalEntry => {
+  const { source: _source, ...rest } = entry;
+  return rest;
+};
+
+const loadSourceState = (): SourceState => {
+  try {
+    const raw = localStorage.getItem(SOURCE_STATE_KEY);
+    if (!raw) {
+      return { ...defaultSourceState };
+    }
+
+    const parsed = JSON.parse(raw);
+    return {
+      journal: parsed.journal ?? {},
+      hasImported: parsed.hasImported ?? false,
+    } as SourceState;
+  } catch (error) {
+    console.warn('⚠️ Impossible de charger l\'état des sources:', error);
+    return { ...defaultSourceState };
+  }
+};
+
+const saveSourceState = (state: SourceState) => {
+  localStorage.setItem(SOURCE_STATE_KEY, JSON.stringify(state));
+};
+
+const matchCanonicalEntry = (entry: JournalEntry): JournalContentEntry | undefined => {
+  return canonicalJournalEntries.find((canonical) => {
+    return (
+      canonical.day === entry.day &&
+      canonical.title === entry.title &&
+      canonical.location === entry.location &&
+      canonical.story === entry.story
+    );
+  });
+};
+
+export const initializeContentStore = () => {
+  try {
+    const existing = localStorage.getItem(JOURNAL_STORAGE_KEY);
+    if (!existing || existing === '[]') {
+      const entriesToSave = canonicalJournalEntries.map(stripSource);
+      localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(entriesToSave));
+      localStorage.setItem(VERSION_KEY, CURRENT_VERSION);
+      saveSourceState({
+        journal: canonicalJournalEntries.reduce<Record<number, ContentSource>>((map, entry) => {
+          map[entry.day] = 'canonical';
+          return map;
+        }, {}),
+        hasImported: false,
+      });
+      return;
+    }
+
+    const parsed: JournalEntry[] = JSON.parse(existing);
+    syncJournalSources(parsed);
+
+    if (!localStorage.getItem(VERSION_KEY)) {
+      localStorage.setItem(VERSION_KEY, CURRENT_VERSION);
+    }
+  } catch (error) {
+    console.error('❌ Erreur lors de l\'initialisation du contentStore:', error);
+  }
+};
+
+export const syncJournalSources = (entries: JournalEntry[]): JournalContentEntry[] => {
+  const state = loadSourceState();
+  let stateChanged = false;
+
+  const entryDays = new Set(entries.map((entry) => entry.day));
+  const syncedEntries = entries.map((entry) => {
+    const canonicalMatch = matchCanonicalEntry(entry);
+    const source: ContentSource = canonicalMatch ? 'canonical' : 'custom';
+
+    if (state.journal[entry.day] !== source) {
+      state.journal[entry.day] = source;
+      stateChanged = true;
+    }
+
+    return {
+      ...entry,
+      source,
+    };
+  });
+
+  Object.keys(state.journal).forEach((key) => {
+    const day = Number(key);
+    if (!entryDays.has(day)) {
+      delete state.journal[day];
+      stateChanged = true;
+    }
+  });
+
+  if (stateChanged) {
+    saveSourceState(state);
+  }
+
+  return syncedEntries;
+};
+
+export const getJournalEntriesWithSource = (entries: JournalEntry[]): JournalContentEntry[] => {
+  return syncJournalSources(entries);
+};
+
+export const isCustomJournalDay = (day: number): boolean => {
+  const state = loadSourceState();
+  return state.journal[day] === 'custom';
+};
+
+export const markJournalDayAsCustom = (day: number) => {
+  const state = loadSourceState();
+  if (state.journal[day] !== 'custom') {
+    state.journal[day] = 'custom';
+    saveSourceState(state);
+  }
+};
+
+export const registerImportedJournalEntries = (entries: JournalEntry[]) => {
+  const state = loadSourceState();
+  entries.forEach((entry) => {
+    state.journal[entry.day] = 'custom';
+  });
+  state.hasImported = true;
+  saveSourceState(state);
+};
+
+export const clearContentStoreState = () => {
+  localStorage.removeItem(SOURCE_STATE_KEY);
+};
+
+export const getCanonicalJournalEntries = (): JournalContentEntry[] => {
+  return [...canonicalJournalEntries];
+};
+
+export const getPlaceReferences = (): PlaceReference[] => {
+  return [...canonicalPlaceReferences];
+};
+
+export const getFoodExperiences = (): FoodExperience[] => {
+  return [...canonicalFoodExperiences];
+};
+
+export const getReadingRecommendations = (): ReadingRecommendation[] => {
+  return [...canonicalReadingRecommendations];
+};

--- a/src/lib/journalStorage.ts
+++ b/src/lib/journalStorage.ts
@@ -13,48 +13,17 @@ const STORAGE_KEY = 'journalEntries';
 const BACKUP_KEY = 'journalEntries_backup';
 const BACKUP_2_KEY = 'journalEntries_backup2';
 const VERSION_KEY = 'journalStorage_version';
-const CURRENT_VERSION = '2.1';
-
-// Pas d'entrées legacy - les vraies données sont dans localStorage
-const LEGACY_ENTRIES: JournalEntry[] = [];
-
-/**
- * Migration automatique - Ajoute les jours 1 et 2 s'ils n'existent pas déjà
- */
-const runMigration = (): void => {
-  try {
-    const version = localStorage.getItem(VERSION_KEY);
-    if (version === CURRENT_VERSION) {
-      console.log('✅ Storage version up to date');
-      return;
-    }
-
-    console.log('🔄 Running migration to version', CURRENT_VERSION);
-    
-    // Charger les entrées existantes
-    const existingEntries = loadJournalEntriesRaw();
-    const existingDays = new Set(existingEntries.map(e => e.day));
-    
-    // Ajouter les jours manquants depuis LEGACY_ENTRIES
-    const entriesToAdd = LEGACY_ENTRIES.filter(entry => !existingDays.has(entry.day));
-    
-    if (entriesToAdd.length > 0) {
-      const allEntries = [...existingEntries, ...entriesToAdd].sort((a, b) => a.day - b.day);
-      const dataToSave = JSON.stringify(allEntries);
-      localStorage.setItem(STORAGE_KEY, dataToSave);
-      console.log(`✅ Migration complete: Added ${entriesToAdd.length} legacy entries`);
-    } else {
-      console.log('✅ Migration complete: No legacy entries to add');
-    }
-    
-    // Marquer la migration comme terminée
-    localStorage.setItem(VERSION_KEY, CURRENT_VERSION);
-  } catch (error) {
-    console.error('❌ Migration failed:', error);
-  }
-};
+const CURRENT_VERSION = '3.0';
 
 import { compressImageUrl } from './imageCompression';
+import {
+  clearContentStoreState,
+  initializeContentStore,
+  markJournalDayAsCustom,
+  registerImportedJournalEntries,
+  syncJournalSources,
+  getCanonicalJournalEntries,
+} from './contentStore';
 
 /**
  * Convertit blob URLs en base64 pour la persistance et nettoie les photos manquantes
@@ -255,9 +224,9 @@ const loadJournalEntriesRaw = (): JournalEntry[] => {
 export const loadJournalEntries = (): JournalEntry[] => {
   try {
     console.log('🔍 Loading journal entries...');
-    
-    // Exécuter la migration si nécessaire
-    runMigration();
+
+    // Initialiser le magasin de contenu (injection des entrées canons au besoin)
+    initializeContentStore();
     
     const saved = localStorage.getItem(STORAGE_KEY);
     console.log('📖 Raw data from storage:', saved?.length ? `${saved.length} chars` : 'empty');
@@ -295,7 +264,9 @@ export const loadJournalEntries = (): JournalEntry[] => {
       saveJournalEntries(validEntries);
     }
 
-    console.log('🎯 Final loaded entries:', validEntries.map(e => `Day ${e.day}: ${e.title}`));
+    const entriesWithSource = syncJournalSources(validEntries);
+
+    console.log('🎯 Final loaded entries:', entriesWithSource.map(e => `Day ${e.day}: ${e.title} (${e.source})`));
     return validEntries;
   } catch (error) {
     console.error('❌ Error loading journal entries:', error);
@@ -318,7 +289,9 @@ export const recoverFromBackup = (): JournalEntry[] => {
         if (Array.isArray(parsed1) && parsed1.length > 0) {
           console.log('✅ Successfully recovered from backup 1:', parsed1.length, 'entries');
           localStorage.setItem(STORAGE_KEY, backup1);
-          return parsed1;
+          const entries = parsed1 as JournalEntry[];
+          syncJournalSources(entries);
+          return entries;
         }
       } catch (e) {
         console.warn('⚠️ Backup 1 corrupted, trying backup 2...');
@@ -333,17 +306,24 @@ export const recoverFromBackup = (): JournalEntry[] => {
         if (Array.isArray(parsed2) && parsed2.length > 0) {
           console.log('✅ Successfully recovered from backup 2:', parsed2.length, 'entries');
           localStorage.setItem(STORAGE_KEY, backup2);
-          return parsed2;
+          const entries = parsed2 as JournalEntry[];
+          syncJournalSources(entries);
+          return entries;
         }
       } catch (e) {
         console.warn('⚠️ Backup 2 corrupted, using legacy entries...');
       }
     }
-    
-    // Dernier recours : utiliser les entrées par défaut (jours 1-2)
-    console.log('📦 Using legacy entries as last resort');
-    saveJournalEntries(LEGACY_ENTRIES);
-    return LEGACY_ENTRIES;
+
+    // Dernier recours : réinjecter les entrées canons
+    console.log('📦 Using canonical entries as last resort');
+    const canonical = getCanonicalJournalEntries().map(entry => {
+      const { source: _source, ...rest } = entry;
+      return rest;
+    });
+    void saveJournalEntries(canonical);
+    syncJournalSources(canonical);
+    return canonical;
     
   } catch (error) {
     console.error('❌ All recovery attempts failed:', error);
@@ -377,7 +357,14 @@ export const addJournalEntry = async (newEntry: JournalEntry): Promise<boolean> 
   // Trier par jour
   updatedEntries.sort((a, b) => a.day - b.day);
   
-  return await saveJournalEntries(updatedEntries);
+  const success = await saveJournalEntries(updatedEntries);
+
+  if (success) {
+    markJournalDayAsCustom(newEntry.day);
+    syncJournalSources(updatedEntries);
+  }
+
+  return success;
 };
 
 /**
@@ -401,7 +388,14 @@ export const updateJournalEntry = async (updatedEntry: JournalEntry): Promise<bo
     // Trier par jour
     updatedEntries.sort((a, b) => a.day - b.day);
     
-    return await saveJournalEntries(updatedEntries);
+    const success = await saveJournalEntries(updatedEntries);
+
+    if (success) {
+      markJournalDayAsCustom(updatedEntry.day);
+      syncJournalSources(updatedEntries);
+    }
+
+    return success;
   } else {
     // Créer nouvelle entrée si elle n'existe pas
     console.log('🆕 Entry not found, creating new one');
@@ -448,8 +442,9 @@ export const diagnosticTools = {
   // Forcer la migration
   forceMigration: () => {
     localStorage.removeItem(VERSION_KEY);
-    runMigration();
-    return loadJournalEntries();
+    initializeContentStore();
+    const entries = loadJournalEntries();
+    return entries;
   },
 
   // Nettoyer et réinitialiser
@@ -457,7 +452,8 @@ export const diagnosticTools = {
     [STORAGE_KEY, BACKUP_KEY, BACKUP_2_KEY, VERSION_KEY].forEach(key => {
       localStorage.removeItem(key);
     });
-    runMigration();
+    clearContentStoreState();
+    initializeContentStore();
     return loadJournalEntries();
   },
 
@@ -501,10 +497,12 @@ export const diagnosticTools = {
       });
 
       console.log(`📥 Importing ${validEntries.length} valid entries`);
-      
+
       const success = await saveJournalEntries(validEntries);
       if (success) {
         console.log('✅ Import successful');
+        registerImportedJournalEntries(validEntries);
+        syncJournalSources(validEntries);
         return { success: true, imported: validEntries.length };
       } else {
         throw new Error('Save failed');

--- a/src/pages/Food.tsx
+++ b/src/pages/Food.tsx
@@ -1,46 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Header } from "@/components/Header";
+import { getFoodExperiences } from "@/lib/contentStore";
 
 const Food = () => {
-  const foodExperiences = [
-    {
-      name: "Mansaf",
-      type: "Plat national",
-      description: "Le plat emblématique jordanien : agneau cuit dans une sauce au yaourt fermenté (jameed), servi sur un lit de riz et mangé traditionnellement avec les mains.",
-      experience: "Partagé lors d'un déjeuner familial à Amman. L'expérience était autant sociale que gustative - toute la famille mange dans le même plat, créant une intimité particulière.",
-      rating: 5,
-      location: "Restaurant familial, Amman",
-      price: "Modéré"
-    },
-    {
-      name: "Falafel et Houmous",
-      type: "Street food",
-      description: "Boulettes de pois chiches frites servies avec houmous crémeux, tahini, et légumes frais dans du pain pita chaud.",
-      experience: "Découvert dans une petite échoppe près du théâtre romain. Le propriétaire m'a expliqué ses secrets : pois chiches trempés 24h et épices moulues chaque matin.",
-      rating: 4,
-      location: "Downtown Amman",
-      price: "Très abordable"
-    },
-    {
-      name: "Knafeh",
-      type: "Dessert",
-      description: "Dessert traditionnel au fromage fondu recouvert de cheveux d'ange (kataifi) et arrosé de sirop parfumé à l'eau de rose.",
-      experience: "Une révélation ! La version de Nablus dégustée à Amman était parfaite : croquant du dessus, fondant à l'intérieur. Un équilibre sucré-salé surprenant.",
-      rating: 5,
-      location: "Pâtisserie Al-Aker, Amman",
-      price: "Abordable"
-    },
-    {
-      name: "Thé à la menthe et café arabe",
-      type: "Boissons",
-      description: "Thé noir parfumé à la menthe fraîche et café arabe (qahwa) parfumé à la cardamome, servis dans de petits verres.",
-      experience: "Rituel quotidien dans chaque lieu visité. Le thé accompagne chaque conversation, chaque pause. Le café arabe, plus corsé, ponctue les moments importants.",
-      rating: 4,
-      location: "Partout",
-      price: "Très abordable"
-    }
-  ];
+  const foodExperiences = getFoodExperiences();
 
   const getRatingStars = (rating: number) => {
     return "⭐".repeat(rating);

--- a/src/pages/Journal.tsx
+++ b/src/pages/Journal.tsx
@@ -18,14 +18,15 @@ const Journal = () => {
   const [fullscreenImage, setFullscreenImage] = useState<string | null>(null);
   const [showDiagnostic, setShowDiagnostic] = useState(false);
   
-  const { 
-    allEntries, 
-    customEntries, 
-    isLoading, 
-    error, 
-    addEntry, 
-    editEntry, 
-    getStats, 
+  const {
+    allEntries,
+    customEntries,
+    isCustom,
+    isLoading,
+    error,
+    addEntry,
+    editEntry,
+    getStats,
     reloadEntries 
   } = useJournalEntries();
 
@@ -174,7 +175,7 @@ const Journal = () => {
                     <div className="flex-1">
                       <CardTitle className="font-serif text-3xl mb-3 text-foreground tracking-wide">
                         Jour {entry.day} — {entry.title}
-                        {customEntries.some(custom => custom.day === entry.day) && (
+                        {isCustom(entry.day) && (
                           <span className="ml-2 text-xs bg-primary/10 text-primary px-2 py-1 rounded-full font-normal">
                             Modifié
                           </span>
@@ -247,7 +248,7 @@ const Journal = () => {
                   )}
                   
                   {/* Photos for custom entries */}
-                  {entry.photos && entry.photos.length > 0 && customEntries.some(custom => custom.day === entry.day) && (
+                  {entry.photos && entry.photos.length > 0 && isCustom(entry.day) && (
                     <div className="mt-6">
                       <h4 className="font-semibold mb-3 text-lg">📸 Photos</h4>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -310,7 +311,7 @@ const Journal = () => {
 
           <div className="text-center mt-12">
             <p className="text-muted-foreground">
-              {customEntries.length > 0 
+              {customEntries.length > 0
                 ? `${allEntries.length} entrées au total (${customEntries.length} personnalisées) - Le voyage continue !`
                 : "Plus d'entrées bientôt... Le voyage continue !"
               }

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -2,64 +2,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Header } from "@/components/Header";
+import { getReadingRecommendations } from "@/lib/contentStore";
 
 const Recommendations = () => {
-  const books = [
-    {
-      title: "Lawrence d'Arabie",
-      author: "T.E. Lawrence",
-      type: "Autobiographie",
-      description: "Le récit captivant de l'officier britannique qui a vécu la révolte arabe de 1916-1918. Une plongée dans l'histoire du Moyen-Orient moderne.",
-      why: "Indispensable pour comprendre l'histoire moderne de la région et l'émergence de la Jordanie moderne sous l'émir Abdallah.",
-      amazon: "https://amazon.fr/...",
-      rating: 5
-    },
-    {
-      title: "Pétra : Merveille du monde",
-      author: "Jane Taylor", 
-      type: "Guide culturel",
-      description: "Guide complet sur l'histoire, l'archéologie et l'art nabatéen de Pétra. Avec de magnifiques photographies et plans détaillés.",
-      why: "Le guide de référence pour comprendre l'ingéniosité nabatéenne et l'importance historique du site.",
-      amazon: "https://amazon.fr/...",
-      rating: 4
-    },
-    {
-      title: "Les Bédouins de Jordanie",
-      author: "Shelagh Weir",
-      type: "Anthropologie",
-      description: "Étude approfondie de la culture bédouine traditionnelle, ses traditions, son artisanat et son mode de vie.",
-      why: "Pour découvrir l'âme nomade de la Jordanie et comprendre l'hospitalité légendaire de ses habitants.",
-      amazon: "https://amazon.fr/...",
-      rating: 4
-    },
-    {
-      title: "Cuisine du Moyen-Orient",
-      author: "Claudia Roden",
-      type: "Gastronomie",
-      description: "Bible de la cuisine moyen-orientale avec des recettes authentiques jordaniennes, palestiniennes et syriennes.",
-      why: "Pour reproduire chez soi les saveurs découvertes et prolonger le voyage culinaire.",
-      amazon: "https://amazon.fr/...",
-      rating: 5
-    },
-    {
-      title: "Jordan: A Timeless Land",
-      author: "Mohamed El-Khoury",
-      type: "Beau livre",
-      description: "Superbe livre photographique qui capture la beauté des paysages jordaniens, de Pétra au Wadi Rum.",
-      why: "Pour revivre visuellement la magie des paysages jordaniens et partager la beauté du pays.",
-      amazon: "https://amazon.fr/...",
-      rating: 4
-    },
-    {
-      title: "Le Royaume hachémite de Jordanie",
-      author: "Philippe Droz-Vincent",
-      type: "Géopolitique",
-      description: "Analyse politique et sociale de la Jordanie contemporaine, son rôle régional et ses défis.",
-      why: "Pour comprendre les enjeux actuels du royaume et son importance stratégique au Moyen-Orient.",
-      amazon: "https://amazon.fr/...",
-      rating: 4
-    }
-  ];
+  const books = getReadingRecommendations();
 
   const getRatingStars = (rating: number) => {
     return "⭐".repeat(rating);


### PR DESCRIPTION
## Summary
- create a centralized contentStore that exposes canonical journal, place, food and reading entries with source metadata
- initialize journal storage with canonical data when needed and surface custom entry detection through useJournalEntries
- update journal UI, reference pages and tests to consume the new store and verify canonical versus custom behaviour

## Testing
- `npx vitest --run` *(fails: npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cffe5876dc8322b54cb842bfee0137