### PR TITLE
Enable strict TypeScript and share journal entry types

### DIFF
--- a/PROJECT_ASSESSMENT.md
+++ b/PROJECT_ASSESSMENT.md
@@ -1,0 +1,75 @@
+# État actuel du projet
+
+## Synthèse rapide
+- La phase 1 du refactoring est documentée comme terminée avec suppression du code mort, introduction d'un logger, d'un ErrorBoundary et sécurisation des secrets. 【F:PHASE1_COMPLETE.md†L1-L90】
+- Le strict mode TypeScript reste désactivé, ce qui limite la détection d'erreurs en amont. 【F:tsconfig.json†L8-L18】
+- Les modules critiques (éditeur, persistance) sont encore monolithiques avec duplication et logs verbeux, symptôme d'une phase 2/3 incomplète. 【F:src/pages/Editor.tsx†L1-L120】【F:src/lib/journalStorage.ts†L1-L120】
+- Le Studio créateur existe mais s'appuie sur les mêmes APIs locales et n'a pas encore de flux de publication/validation complet. 【F:src/pages/Studio.tsx†L1-L120】
+
+## Risques identifiés
+1. **Dette technique persistante**
+   - `Editor.tsx`, `journalStorage.ts` et `contentStore.ts` restent des fichiers >500 lignes avec responsabilités multiples, ce qui complique l'évolution. 【F:src/pages/Editor.tsx†L1-L120】【F:src/lib/contentStore.ts†L1-L120】
+   - Les hooks comme `useJournalEntries` gardent des `console.log` bruités et acceptent des `any` en entrée, faute de typage strict. 【F:src/hooks/useJournalEntries.ts†L1-L120】
+2. **Robustesse insuffisante**
+   - Persistance localStorage non factorisée (gestion d'erreurs, quotas, migrations) et absence de fallback serveur.
+   - Les données canoniques sont en dur dans `contentStore`/`contentStore.ts` et dupliquées entre modules (ex: expériences culinaires). 【F:src/lib/contentStore.ts†L33-L120】【F:src/store/contentStore.ts†L1-L120】
+3. **Expérience Studio à finaliser**
+   - Pas de workflow clair pour passer d'un contenu créé dans le studio à une publication sur les pages publiques.
+   - Pas de stratégie média (optimisation, stockage) ni de support multi-auteurs.
+
+# Plan proposé pour la Phase 3 du refactoring
+
+## Objectif général
+Consolider l'architecture afin de rendre la création de contenu stable, typée et prête pour des itérations rapides dans le Studio.
+
+## Étapes recommandées
+1. **Durcir le socle TypeScript & lint**
+   - Activer `strict`, `noImplicitAny`, `noUnusedLocals` et `noUnusedParameters`, puis corriger les erreurs remontées, en priorité dans `useJournalEntries`, `journalStorage` et l'éditeur. 【F:tsconfig.json†L8-L18】【F:src/hooks/useJournalEntries.ts†L1-L120】
+   - Introduire des types dédiés pour les formulaires (`JournalEntryFormData`, `PersistedJournalEntry`) pour bannir `any`.
+2. **Isoler la couche persistance**
+   - Extraire un module `storage/localStorageClient.ts` qui gère sérialisation, quotas et migrations (utiliser `CURRENT_VERSION` déjà présent). 【F:src/lib/journalStorage.ts†L1-L120】
+   - Scinder `journalStorage.ts` en services : `photoProcessing.ts`, `journalRepository.ts`, `journalMigrations.ts`.
+   - Ajouter une interface `ContentRepository` pour préparer une future API backend.
+3. **Factoriser l'éditeur**
+   - Transformer `Editor.tsx` en conteneur + sous-composants génériques (`GenericListEditor`, `EntryForm`). 【F:src/pages/Editor.tsx†L1-L120】
+   - Mutualiser les champs et validations via un hook `useEditableCollection<T>`.
+4. **Nettoyer les stores de contenu**
+   - Déplacer les données canoniques dans `src/data/` et exposer des adapters depuis `contentStore`. 【F:src/lib/contentStore.ts†L1-L120】【F:src/store/contentStore.ts†L1-L120】
+   - Unifier la structure `FoodExperience`/`ReadingRecommendation` pour éviter duplication entre `lib` et `store`.
+5. **Instrumentation & tests légers**
+   - Remplacer les `console.log` restants par le logger central. 【F:src/hooks/useJournalEntries.ts†L19-L50】
+   - Ajouter des tests unitaires ciblés (ex: migrations, repository) avec Vitest + React Testing Library.
+   - Mettre en place un script npm `npm run lint && npm run typecheck && npm run test` en CI.
+
+# Plan pour finaliser le site et le Studio
+
+1. **Flux de création → publication**
+   - Implémenter un mode "brouillon" et "publié" dans le store, avec actions explicites dans le Studio (`Publier`, `Revenir en brouillon`).
+   - Synchroniser automatiquement les pages publiques (`Journal`, `Food`, etc.) via un selector qui agrège contenu canonique + custom publié.
+2. **Gestion média**
+   - Finaliser `MediaManager` : upload, compression asynchrone (Web Worker) et association aux entrées.
+   - Mettre en place un quota visuel et un diagnostic dans l'onglet Studio > Diagnostics.
+3. **Améliorations UX**
+   - Ajouter un indicateur de progression (steps) et de validation des champs dans l'éditeur.
+   - Implémenter une recherche globale (Fuse.js déjà listé en quick win) pour naviguer dans les contenus.
+4. **Contenu & SEO**
+   - Préparer des templates MD/JSON exportables depuis le Studio pour accélérer la production via Lovable Studio.
+   - Ajouter métadonnées SEO par page, sitemap et pré-chargement des images critiques (cf. audit). 【F:README-AUDIT.md†L64-L108】
+5. **Stabilité & Monitoring**
+   - Ajouter un `ErrorBoundary` spécifique autour des zones critiques (Studio, Map) avec relance.
+   - Prévoir instrumentation (Sentry ou console logger) pour suivre erreurs de persistance.
+
+## Livrables attendus
+- Architecture modulée (`storage/`, `repositories/`, `features/editor/`).
+- Tests de persistance et hooks clés.
+- Pages publiques alimentées dynamiquement par les données du Studio.
+- Documentation de l'orchestration (README technique + guide Studio).
+
+# Journal d'avancement Phase 3
+
+## Étape 1 — Durcissement TypeScript & lint (en cours → ✅)
+- ✅ Activation de `strict`, `noImplicitAny`, `noUnusedLocals` et `noUnusedParameters` dans la configuration TypeScript.
+- ✅ Création des types partagés `PersistedJournalEntry` et `JournalEntryFormData` (`src/types/journal.ts`).
+- ✅ Mutualisation de la transformation formulaire → persistance via `toPersistedJournalEntry` (`src/lib/journalMapper.ts`).
+- ✅ Mise à jour des hooks (`useJournalEntries`) et du Studio pour éliminer les usages de `any` et centraliser le mapping.
+- 🔜 Prochaine étape : isoler la couche de persistance (`storage/localStorageClient.ts`) avant de découper `journalStorage.ts`.

--- a/src/components/AddJournalEntryForm.tsx
+++ b/src/components/AddJournalEntryForm.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm, UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import type { JournalEntryFormData, PersistedJournalEntry } from "@/types/journal";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { CalendarIcon, Plus, X } from "lucide-react";
@@ -56,7 +57,7 @@ const parseFrenchDate = (dateString: string): Date | undefined => {
 };
 
 // Define the schema for form validation
-const journalEntrySchema = z.object({
+const journalEntrySchema: z.ZodType<JournalEntryFormData> = z.object({
   day: z.number().min(1, "Le jour doit être au moins 1"),
   date: z.date({
     required_error: "La date est requise",
@@ -69,21 +70,10 @@ const journalEntrySchema = z.object({
   photos: z.array(z.string()).optional(),
 });
 
-export type JournalEntryFormData = z.infer<typeof journalEntrySchema>;
-
 export interface AddJournalEntryFormProps {
   onSubmit: (entry: JournalEntryFormData) => Promise<boolean | void> | boolean | void;
   onCancel: () => void;
-  editEntry?: {
-    day: number;
-    date: string;
-    title: string;
-    location: string;
-    story: string;
-    mood: string;
-    photos?: string[];
-    link?: string;
-  };
+  editEntry?: PersistedJournalEntry;
 }
 
 const MOOD_OPTIONS = [

--- a/src/components/studio/EntryFormPanel.tsx
+++ b/src/components/studio/EntryFormPanel.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { AddJournalEntryFormProps, JournalEntryForm, JournalEntryFormData, JournalEntryPreview, useJournalEntryForm } from "@/components/AddJournalEntryForm";
+import { AddJournalEntryFormProps, JournalEntryForm, JournalEntryPreview, useJournalEntryForm } from "@/components/AddJournalEntryForm";
 import { JournalEntry } from "@/lib/journalStorage";
 import { toast } from "sonner";
+import type { JournalEntryFormData } from "@/types/journal";
 
 interface EntryFormPanelProps {
   mode: "create" | "edit";

--- a/src/hooks/useJournalEntries.ts
+++ b/src/hooks/useJournalEntries.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
-  JournalEntry,
   loadJournalEntries,
   updateJournalEntry,
   addJournalEntry,
@@ -11,6 +10,8 @@ import {
   isCustomJournalDay
 } from '@/lib/contentStore';
 import type { JournalContentEntry } from '@/lib/contentStore';
+import type { JournalEntryFormData } from '@/types/journal';
+import { toPersistedJournalEntry } from '@/lib/journalMapper';
 
 // Plus de defaultEntries - tout est maintenant unifié dans le système de persistance
 
@@ -59,26 +60,11 @@ export const useJournalEntries = () => {
   }, [allEntries]);
 
   // Ajouter une nouvelle entrée
-  const addEntry = useCallback(async (formData: any): Promise<boolean> => {
+  const addEntry = useCallback(async (formData: JournalEntryFormData): Promise<boolean> => {
     console.log('➕ Adding new entry:', formData.title);
     
     try {
-      const newEntry: JournalEntry = {
-        day: formData.day,
-        date: formData.date.toLocaleDateString('fr-FR', { 
-          day: 'numeric', 
-          month: 'long', 
-          year: 'numeric' 
-        }),
-        title: formData.title,
-        location: formData.location,
-        story: formData.story,
-        mood: formData.mood,
-        photos: formData.photos || [],
-        link: formData.link || undefined,
-      };
-
-      const success = await addJournalEntry(newEntry);
+      const success = await addJournalEntry(toPersistedJournalEntry(formData));
 
       if (success) {
         // Recharger toutes les données depuis le localStorage
@@ -95,29 +81,14 @@ export const useJournalEntries = () => {
       setError('Erreur lors de l\'ajout de l\'entrée');
       return false;
     }
-  }, []);
+  }, [loadEntriesFromStorage]);
 
   // Modifier une entrée existante
-  const editEntry = useCallback(async (formData: any, originalDay: number): Promise<boolean> => {
+  const editEntry = useCallback(async (formData: JournalEntryFormData, originalDay: number): Promise<boolean> => {
     console.log('✏️ Editing entry for day:', originalDay, 'new title:', formData.title);
     
     try {
-      const updatedEntry: JournalEntry = {
-        day: formData.day,
-        date: formData.date.toLocaleDateString('fr-FR', { 
-          day: 'numeric', 
-          month: 'long', 
-          year: 'numeric' 
-        }),
-        title: formData.title,
-        location: formData.location,
-        story: formData.story,
-        mood: formData.mood,
-        photos: formData.photos || [],
-        link: formData.link || undefined,
-      };
-
-      const success = await updateJournalEntry(updatedEntry);
+      const success = await updateJournalEntry(toPersistedJournalEntry(formData));
 
       // Toujours recharger les données et retourner true pour fermer le formulaire
       loadEntriesFromStorage();

--- a/src/lib/journalMapper.ts
+++ b/src/lib/journalMapper.ts
@@ -1,0 +1,20 @@
+import type { JournalEntryFormData, PersistedJournalEntry } from "@/types/journal";
+
+const formatJournalDate = (date: Date): string =>
+  date.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+export const toPersistedJournalEntry = (data: JournalEntryFormData): PersistedJournalEntry => ({
+  day: data.day,
+  date: formatJournalDate(data.date),
+  title: data.title,
+  location: data.location,
+  story: data.story,
+  mood: data.mood,
+  photos: data.photos && data.photos.length > 0 ? data.photos : undefined,
+  link: data.link?.trim() ? data.link : undefined,
+});
+

--- a/src/lib/journalStorage.ts
+++ b/src/lib/journalStorage.ts
@@ -1,13 +1,7 @@
-export type JournalEntry = {
-  day: number;
-  date: string;
-  title: string;
-  location: string;
-  story: string;
-  mood: string;
-  photos?: string[];
-  link?: string;
-};
+import type { PersistedJournalEntry } from "@/types/journal";
+
+export type JournalEntry = PersistedJournalEntry;
+export type { PersistedJournalEntry };
 
 const STORAGE_KEY = 'journalEntries';
 const BACKUP_KEY = 'journalEntries_backup';

--- a/src/pages/Studio.tsx
+++ b/src/pages/Studio.tsx
@@ -10,26 +10,12 @@ import { MapEditor } from "@/components/studio/MapEditor";
 import { MediaManager } from "@/components/studio/MediaManager";
 import { useJournalEntries } from "@/hooks/useJournalEntries";
 import { JournalEntry } from "@/lib/journalStorage";
-import { JournalEntryFormData } from "@/components/AddJournalEntryForm";
+import type { JournalEntryFormData } from "@/types/journal";
+import { toPersistedJournalEntry } from "@/lib/journalMapper";
 import { JournalDiagnostic } from "@/components/JournalDiagnostic";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { RotateCw, NotebookPen, Map as MapIcon, UtensilsCrossed, BookOpen, Images, Activity } from "lucide-react";
-
-const formatFormDataToEntry = (data: JournalEntryFormData): JournalEntry => ({
-  day: data.day,
-  date: data.date.toLocaleDateString("fr-FR", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  }),
-  title: data.title,
-  location: data.location,
-  story: data.story,
-  mood: data.mood,
-  photos: data.photos || [],
-  link: data.link || undefined,
-});
 
 const Studio = () => {
   const [mode, setMode] = useState<"create" | "edit">("create");
@@ -50,7 +36,7 @@ const Studio = () => {
   }, []);
 
   const handleEntrySaved = useCallback((data: JournalEntryFormData) => {
-    const entry = formatFormDataToEntry(data);
+    const entry = toPersistedJournalEntry(data);
     setSelectedEntry(entry);
     setMode("edit");
   }, []);

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -1,0 +1,25 @@
+export interface PersistedJournalEntry {
+  day: number;
+  date: string;
+  title: string;
+  location: string;
+  story: string;
+  mood: string;
+  photos?: string[];
+  link?: string;
+}
+
+export interface JournalEntryFormData {
+  day: number;
+  date: Date;
+  title: string;
+  location: string;
+  story: string;
+  mood: string;
+  photos?: string[];
+  link?: string;
+}
+
+export interface JournalEntryWithSource extends PersistedJournalEntry {
+  source: 'canonical' | 'custom';
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,11 +15,11 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
-    "noFallthroughCasesInSwitch": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
 
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,12 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "noImplicitAny": false,
-    "noUnusedParameters": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "noUnusedLocals": false,
-    "strictNullChecks": false
+    "noUnusedLocals": true,
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
## Summary
- enable strict compiler flags in the TypeScript configs to surface unsafe patterns
- introduce shared journal entry domain types and a mapper to reuse the form-to-storage conversion
- update Studio and hooks to consume the shared types and document completion of phase 3 step 1

## Testing
- npx tsc --noEmit
- npm run lint *(fails: existing lint issues in unrelated files, see JournalDiagnostic.tsx, SimpleMap.tsx, logger.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68e16c1a4a288322a2ca9f3608f27172